### PR TITLE
Add supported Django versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,9 @@ Provides rapidjson support with parser and renderer.
         :target: https://pypi.python.org/pypi/djangorestframework-rapidjson
         :alt: Supported Python versions
 
+.. image:: https://img.shields.io/pypi/djversions/djangorestframework-rapidjson.svg
+        :target: https://pypi.python.org/pypi/djangorestframework-rapidjson
+        :alt: Supported Django versions
 
 How to install
 --------------

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
         'Framework :: Django',
+        'Framework :: Django :: 1.11',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',


### PR DESCRIPTION
Closes #1 

@allisson The Django versions badge will properly populate after the next release is pushed to PyPI